### PR TITLE
Perf: add event handlers on root element

### DIFF
--- a/src/renderers/UIButton.ts
+++ b/src/renderers/UIButton.ts
@@ -1,7 +1,7 @@
 import { onPropertyChange, UIButton, UIFocusRequestEvent, UIRenderEvent } from "typescene";
 import { BrowserApplication, BrowserHashActivationContext } from "../BrowserApplication";
 import { applyElementCSS } from "../DOMStyle";
-import { baseEventNames, controlEventNames, RendererBase } from "./RendererBase";
+import { RendererBase } from "./RendererBase";
 import { setTextOrHtmlContent } from "./UILabel";
 
 class UIButtonRenderer extends RendererBase<
@@ -10,6 +10,7 @@ class UIButtonRenderer extends RendererBase<
 > {
   constructor(public component: UIButton) {
     super(component);
+    this.DOM_CONTROL_EMIT = this.DOM_EMIT;
   }
 
   /** Create output element, used by base class */
@@ -58,13 +59,6 @@ class UIButtonRenderer extends RendererBase<
       }
     });
     return element;
-  }
-
-  /** Called after rendering: add event handlers */
-  protected afterRender() {
-    this.propagateDOMEvents(baseEventNames);
-    this.propagateDOMEvents(controlEventNames);
-    super.afterRender();
   }
 
   /** Handle render event */

--- a/src/renderers/UIContainer.ts
+++ b/src/renderers/UIContainer.ts
@@ -15,7 +15,7 @@ import {
 import { DOMRenderContext } from "../DOMRenderContext";
 import { applyElementCSS } from "../DOMStyle";
 import { DOMContainerUpdater } from "./DOMContainerUpdater";
-import { baseEventNames, cellEventNames, RendererBase } from "./RendererBase";
+import { RendererBase } from "./RendererBase";
 
 /** Type for containers that have a `spacing` property */
 type UIContainerWithSpacing = UIRow | UIColumn;
@@ -32,6 +32,9 @@ class UIContainerRenderer extends RendererBase<UIContainer, HTMLElement> {
   constructor(component: any) {
     super(component);
     this.component = component;
+    if (component instanceof UICell) {
+      this.DOM_CELL_EMIT = this.DOM_EMIT;
+    }
   }
 
   component: UIContainer;
@@ -49,15 +52,6 @@ class UIContainerRenderer extends RendererBase<UIContainer, HTMLElement> {
 
   /** Called after rendering: add base event handlers */
   protected afterRender() {
-    this.propagateDOMEvents(baseEventNames);
-    if (this.component instanceof UICell) {
-      // handle mouseenter/leave specially, only on cells
-      this.propagateDOMEvents(cellEventNames);
-    }
-    if (this.component.accessibleRole === "form") {
-      // handle form submit (default prevented in RendererBase)
-      this.propagateDOMEvents(["submit"]);
-    }
     super.afterRender();
 
     // capture scroll events on scroll containers

--- a/src/renderers/UIImage.ts
+++ b/src/renderers/UIImage.ts
@@ -6,11 +6,12 @@ import {
   UIRenderEvent,
 } from "typescene";
 import { applyElementCSS } from "../DOMStyle";
-import { baseEventNames, controlEventNames, RendererBase } from "./RendererBase";
+import { RendererBase } from "./RendererBase";
 
 class UIImageRenderer extends RendererBase<UIImage, HTMLImageElement> {
   constructor(public component: UIImage) {
     super(component);
+    this.DOM_CONTROL_EMIT = this.DOM_EMIT;
   }
 
   /** Create output element, used by base class */
@@ -24,13 +25,6 @@ class UIImageRenderer extends RendererBase<UIImage, HTMLImageElement> {
     applyElementCSS(this.component, element, true);
     element.src = this.component.url || "";
     return element;
-  }
-
-  /** Called after rendering: add event handlers */
-  protected afterRender() {
-    this.propagateDOMEvents(baseEventNames);
-    this.propagateDOMEvents(controlEventNames);
-    super.afterRender();
   }
 
   /** Handle render event */

--- a/src/renderers/UILabel.ts
+++ b/src/renderers/UILabel.ts
@@ -8,11 +8,12 @@ import {
   UITheme,
 } from "typescene";
 import { applyElementCSS, getCSSLength } from "../DOMStyle";
-import { baseEventNames, controlEventNames, RendererBase } from "./RendererBase";
+import { RendererBase } from "./RendererBase";
 
 class UILabelRenderer extends RendererBase<UILabel, HTMLElement> {
   constructor(public component: UILabel) {
     super(component);
+    this.DOM_CONTROL_EMIT = this.DOM_EMIT;
   }
 
   /** Create output element, used by base class */
@@ -33,13 +34,6 @@ class UILabelRenderer extends RendererBase<UILabel, HTMLElement> {
       iconAfter: this.component.iconAfter,
     });
     return element;
-  }
-
-  /** Called after rendering: add event handlers */
-  protected afterRender() {
-    this.propagateDOMEvents(baseEventNames);
-    this.propagateDOMEvents(controlEventNames);
-    super.afterRender();
   }
 
   /** Handle render event */

--- a/src/renderers/UISeparator.ts
+++ b/src/renderers/UISeparator.ts
@@ -1,6 +1,6 @@
 import { onPropertyChange, UIRenderEvent, UISeparator } from "typescene";
 import { applyElementCSS, getCSSLength } from "../DOMStyle";
-import { baseEventNames, RendererBase } from "./RendererBase";
+import { RendererBase } from "./RendererBase";
 
 class UISeparatorRenderer extends RendererBase<UISeparator, HTMLElement> {
   constructor(public component: UISeparator) {
@@ -19,12 +19,6 @@ class UISeparatorRenderer extends RendererBase<UISeparator, HTMLElement> {
       element.style.margin = this.component.vertical ? "0 " + margin : margin + " 0";
     }
     return element;
-  }
-
-  /** Called after rendering: add event handlers */
-  protected afterRender() {
-    this.propagateDOMEvents(baseEventNames);
-    super.afterRender();
   }
 
   /** Handle render event */

--- a/src/renderers/UITextField.ts
+++ b/src/renderers/UITextField.ts
@@ -5,7 +5,7 @@ import {
   UITextField,
 } from "typescene";
 import { applyElementCSS } from "../DOMStyle";
-import { baseEventNames, controlEventNames, RendererBase } from "./RendererBase";
+import { RendererBase } from "./RendererBase";
 
 class UITextFieldRenderer extends RendererBase<
   UITextField,
@@ -13,6 +13,7 @@ class UITextFieldRenderer extends RendererBase<
 > {
   constructor(public component: UITextField) {
     super(component);
+    this.DOM_CONTROL_EMIT = this.DOM_EMIT;
   }
 
   /** Create output element, used by base class */
@@ -38,13 +39,6 @@ class UITextFieldRenderer extends RendererBase<
       this.component.value = element.value;
     }
     super.emitComponentEvent(e);
-  }
-
-  /** Called after rendering: add event handlers */
-  protected afterRender() {
-    this.propagateDOMEvents(baseEventNames);
-    this.propagateDOMEvents(controlEventNames);
-    super.afterRender();
   }
 
   /** Handle render event */

--- a/src/renderers/UIToggle.ts
+++ b/src/renderers/UIToggle.ts
@@ -6,11 +6,12 @@ import {
   UIToggle,
 } from "typescene";
 import { applyElementCSS } from "../DOMStyle";
-import { baseEventNames, controlEventNames, RendererBase } from "./RendererBase";
+import { RendererBase } from "./RendererBase";
 
 class UIToggleRenderer extends RendererBase<UIToggle, HTMLElement> {
   constructor(public component: UIToggle) {
     super(component);
+    this.DOM_CONTROL_EMIT = this.DOM_EMIT;
   }
 
   /** Create output element, used by base class */
@@ -45,13 +46,6 @@ class UIToggleRenderer extends RendererBase<UIToggle, HTMLElement> {
     if (e.type === "click") {
       super.emitComponentEvent(e, "Input");
     }
-  }
-
-  /** Called after rendering: add event handlers */
-  protected afterRender() {
-    this.propagateDOMEvents(baseEventNames);
-    this.propagateDOMEvents(controlEventNames);
-    super.afterRender();
   }
 
   /** Handle render event */


### PR DESCRIPTION
Perf fixes:
* Add event handlers on root element only, and call method on renderers dynamically
* Make Rendered a ManagedEvent instead of a ComponentEvent => this means it is NOT propagated anymore, since this is no longer necessary and has a large perf impact.