### PR TITLE
Cleanup and features for v3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist/
+dist-*/
 umd/
 node_modules/
 *.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,20 +14,29 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+      "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/helper-validator-identifier": "^7.14.0",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
+      }
+    },
+    "@rollup/plugin-alias": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.1.2.tgz",
+      "integrity": "sha512-wzDnQ6v7CcoRzS0qVwFPrFdYA4Qlr+ookA217Y2Z3DPZE1R8jrFNM3jvGgOf6o6DMjbnQIn5lCIJgHPe1Bt3uw==",
+      "dev": true,
+      "requires": {
+        "slash": "^3.0.0"
       }
     },
     "@rollup/plugin-multi-entry": {
@@ -78,9 +87,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
-      "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.1.tgz",
+      "integrity": "sha512-TMkXt0Ck1y0KKsGr9gJtWGjttxlZnnvDtphxUOSd0bfaR6Q1jle+sPvrzNR1urqYTWMinoKvjKfXUGsumaO1PA==",
       "dev": true
     },
     "@types/resolve": {
@@ -379,13 +388,19 @@
       }
     },
     "rollup": {
-      "version": "2.45.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.45.2.tgz",
-      "integrity": "sha512-kRRU7wXzFHUzBIv0GfoFFIN3m9oteY4uAsKllIpQDId5cfnkWF2J130l+27dzDju0E6MScKiV0ZM5Bw8m4blYQ==",
+      "version": "2.46.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.46.0.tgz",
+      "integrity": "sha512-qPGoUBNl+Z8uNu0z7pD3WPTABWRbcOwIrO/5ccDJzmrtzn0LVf6Lj91+L5CcWhXl6iWf23FQ6m8Jkl2CmN1O7Q==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.1"
       }
+    },
+    "rollup-plugin-gzip": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-gzip/-/rollup-plugin-gzip-2.5.0.tgz",
+      "integrity": "sha512-1N0xtJJ8XfZYklZN1QcMLe+Mos2Vaccy3YUarE/AB1RkH7mkeppkFAz9srh+9KWOC3I2LWJeAYwFabO0rJ4mxg==",
+      "dev": true
     },
     "rollup-plugin-terser": {
       "version": "7.0.2",
@@ -413,6 +428,12 @@
       "requires": {
         "randombytes": "^2.1.0"
       }
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
     },
     "source-map": {
       "version": "0.7.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "index.d.ts"
   ],
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "rimraf dist dist-es6 dist-es8",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean && tsc -p src --declaration",
     "build-es8": "tsc -p src --target es2017 --outDir dist-es8 --removeComments",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   "typings": "./index.d.ts",
   "files": [
     "dist",
+    "dist-es6",
+    "dist-es8",
     "umd",
     "index.js",
     "index.d.ts"
@@ -28,20 +30,24 @@
   "scripts": {
     "clean": "rimraf dist",
     "prepublishOnly": "npm run build",
-    "prebuild": "rimraf dist && tsc -p src --declaration",
-    "postbuild": "rollup -c",
-    "build": "tsc -p src --removeComments",
-    "watch": "tsc -p src -w"
+    "prebuild": "npm run clean && tsc -p src --declaration",
+    "build-es8": "tsc -p src --target es2017 --outDir dist-es8 --removeComments",
+    "build-es6": "tsc -p src --target es2015 --outDir dist-es6 --removeComments",
+    "build-es5": "tsc -p src --removeComments",
+    "build": "npm run build-es5 && npm run build-es6 && npm run build-es8",
+    "postbuild": "rollup -c"
   },
   "dependencies": {
     "typescene": "file:../typescene",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "rimraf": "^3.0.2",
-    "rollup": "^2.45.2",
+    "@rollup/plugin-alias": "^3.1.2",
     "@rollup/plugin-multi-entry": "^4.0.0",
     "@rollup/plugin-node-resolve": "^11.2.1",
+    "rimraf": "^3.0.2",
+    "rollup": "^2.45.2",
+    "rollup-plugin-gzip": "^2.5.0",
     "rollup-plugin-terser": "^7.0.2",
     "typescript": "*"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,9 @@
+import * as path from "path";
 import multiEntry from "@rollup/plugin-multi-entry";
+import alias from "@rollup/plugin-alias";
 import resolve from "@rollup/plugin-node-resolve";
 import { terser } from "rollup-plugin-terser";
+import gzip from "rollup-plugin-gzip";
 
 export default [
   {
@@ -10,7 +13,78 @@ export default [
       format: "umd",
       name: "typescene",
     },
-    plugins: [multiEntry(), resolve(), terser()],
+    plugins: [
+      multiEntry(),
+      resolve(),
+      terser({
+        ecma: 5,
+        module: true,
+        keep_classnames: true,
+      }),
+      gzip(),
+    ],
+    onwarn: warning => {
+      if (warning.code !== "CIRCULAR_DEPENDENCY") {
+        console.warn(`- ${warning.message}`);
+      }
+    },
+  },
+  {
+    input: ["dist-es6/index.js", "node_modules/typescene/dist-es6/index.js"],
+    output: {
+      file: "umd/typescene.es6.min.js",
+      format: "umd",
+      name: "typescene",
+    },
+    plugins: [
+      multiEntry(),
+      alias({
+        entries: [
+          {
+            find: "typescene",
+            replacement: path.resolve(process.cwd(), "node_modules/typescene/dist-es6"),
+          },
+        ],
+      }),
+      resolve(),
+      terser({
+        ecma: 2015,
+        module: true,
+        keep_classnames: true,
+      }),
+      gzip(),
+    ],
+    onwarn: warning => {
+      if (warning.code !== "CIRCULAR_DEPENDENCY") {
+        console.warn(`- ${warning.message}`);
+      }
+    },
+  },
+  {
+    input: ["dist-es8/index.js", "node_modules/typescene/dist-es8/index.js"],
+    output: {
+      file: "umd/typescene.es8.min.js",
+      format: "umd",
+      name: "typescene",
+    },
+    plugins: [
+      multiEntry(),
+      alias({
+        entries: [
+          {
+            find: "typescene",
+            replacement: path.resolve(process.cwd(), "node_modules/typescene/dist-es8"),
+          },
+        ],
+      }),
+      resolve(),
+      terser({
+        ecma: 2017,
+        module: true,
+        keep_classnames: true,
+      }),
+      gzip(),
+    ],
     onwarn: warning => {
       if (warning.code !== "CIRCULAR_DEPENDENCY") {
         console.warn(`- ${warning.message}`);

--- a/src/BrowserApplication.ts
+++ b/src/BrowserApplication.ts
@@ -1,11 +1,6 @@
 import { AppActivationContext, Application } from "typescene";
 import { DOMRenderContext } from "./DOMRenderContext";
-import {
-  DP_PER_REM,
-  importStylesheet,
-  setGlobalCSS,
-  clearGlobalCSSState,
-} from "./DOMStyle";
+import { importStylesheet, clearGlobalCSSState, setGlobalDpSize } from "./DOMStyle";
 import { autoUpdateHandler } from "./HMR";
 
 let _transitionsDisabled = false;
@@ -17,10 +12,7 @@ Application.setAutoUpdateHandler(autoUpdateHandler);
 export class BrowserApplication extends Application {
   /** Set global (page-wide) relative size of DP units in nominal pixels, defaults to 1 */
   static setGlobalDpSize(size = 1) {
-    size *= DP_PER_REM;
-    setGlobalCSS({
-      html: { fontSize: size + "px" },
-    });
+    setGlobalDpSize(size);
   }
 
   /** Import an external stylesheet from given URL (asynchronously) */

--- a/src/BrowserApplication.ts
+++ b/src/BrowserApplication.ts
@@ -6,8 +6,12 @@ import {
   setGlobalCSS,
   clearGlobalCSSState,
 } from "./DOMStyle";
+import { autoUpdateHandler } from "./HMR";
 
 let _transitionsDisabled = false;
+
+// Use HMR as auto-update mechanism
+Application.setAutoUpdateHandler(autoUpdateHandler);
 
 /** Represents an application that runs in a browser using the available DOM APIs. Automatically creates a renderer that renders all UI components in the browser. */
 export class BrowserApplication extends Application {

--- a/src/BrowserTheme.ts
+++ b/src/BrowserTheme.ts
@@ -415,6 +415,14 @@ function initializeCSS() {
       borderBottom: ".125rem solid #fff",
       borderRight: ".125rem solid #fff",
     },
+
+    // fix alignment of text withing <a> button
+    "a.UI": {
+      display: "flex",
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+    },
   });
 
   // add all predefined transitions:

--- a/src/BrowserTheme.ts
+++ b/src/BrowserTheme.ts
@@ -288,7 +288,7 @@ function initializeCSS() {
     ".UI": {
       margin: "0",
       padding: "0",
-      border: "0",
+      border: "0 solid transparent",
       outline: "0",
       cursor: "inherit",
       boxSizing: "border-box",

--- a/src/BrowserTheme.ts
+++ b/src/BrowserTheme.ts
@@ -416,11 +416,10 @@ function initializeCSS() {
       borderRight: ".125rem solid #fff",
     },
 
-    // fix alignment of text withing <a> button
+    // fix vertical alignment of text within <a> button
     "a.UI": {
       display: "flex",
-      flexDirection: "row",
-      alignItems: "center",
+      flexDirection: "column",
       justifyContent: "center",
     },
   });

--- a/src/DOMRenderContext.ts
+++ b/src/DOMRenderContext.ts
@@ -123,7 +123,7 @@ export class DOMRenderContext extends UIRenderContext {
     if (lowPriority && !_pendingNextRender) _pendingNextRender = [];
     if (!_pendingRender) {
       _pendingRender = [];
-      const f = () => {
+      const f: Function = () => {
         // record start time and keep going until time runs out
         let t = Date.now();
         while ((_pendingRender && _pendingRender.length) || _pendingNextRender) {
@@ -149,7 +149,12 @@ export class DOMRenderContext extends UIRenderContext {
       };
       const reschedule = () => {
         if (typeof window.requestAnimationFrame === "function") {
-          window.requestAnimationFrame(f);
+          let fired = 0;
+          const fire = () => {
+            fired || f((fired = 1));
+          };
+          window.requestAnimationFrame(fire);
+          setTimeout(fire, 200);
         } else {
           setTimeout(f, 10);
         }

--- a/src/DOMRenderContext.ts
+++ b/src/DOMRenderContext.ts
@@ -1,6 +1,8 @@
 import {
   AppActivity,
   logUnhandledException,
+  managedChild,
+  ManagedObject,
   UIComponent,
   UIComponentEvent,
   UIRenderable,
@@ -9,6 +11,72 @@ import {
   UITheme,
 } from "typescene";
 import { BrowserApplication } from "./BrowserApplication";
+import { getWindowInnerHeightDp, getWindowInnerWidthDp } from "./DOMStyle";
+
+const DEFAULT_SMALL_BREAKPOINT = 590;
+const DEFAULT_LARGE_BREAKPOINT = 1150;
+
+/** Viewport Context object for measurements based on `window` */
+class DOMViewportContext extends ManagedObject {
+  /** The viewport width in dp units */
+  width?: number;
+
+  /** The viewport height in dp units */
+  height?: number;
+
+  /** True if the viewport width is smaller than the first breakpoint */
+  narrow = false;
+
+  /** True if the viewport width is larger than the second breakpoint */
+  wide = false;
+
+  /** True if the viewport height is smaller than the first breakpoint */
+  short = false;
+
+  /** True if the viewport height is larger than the second breakpoint */
+  tall = false;
+
+  /** Set breakpoints for narrow, wide, short and tall properties to given values (in dp units), and update all properties */
+  setBreakpoints(small: number, large: number) {
+    this._smallBreakpoint = small;
+    this._largeBreakpoint = large;
+    this.update();
+  }
+
+  /** Measure the current viewport and update context properties */
+  update() {
+    let changed = false;
+    let w = getWindowInnerWidthDp();
+    let h = getWindowInnerHeightDp();
+    let narrow = w < this._smallBreakpoint;
+    let wide = w > this._largeBreakpoint;
+    let short = h < this._smallBreakpoint;
+    let tall = h > this._largeBreakpoint;
+    this.width = w;
+    this.height = h;
+    if (this.narrow !== narrow) {
+      this.narrow = narrow;
+      changed = true;
+    }
+    if (this.wide !== wide) {
+      this.wide = wide;
+      changed = true;
+    }
+    if (this.short !== short) {
+      this.short = short;
+      changed = true;
+    }
+    if (this.tall !== tall) {
+      this.tall = tall;
+      changed = true;
+    }
+    if (changed) this.emitChange();
+    return false;
+  }
+
+  private _smallBreakpoint = DEFAULT_SMALL_BREAKPOINT;
+  private _largeBreakpoint = DEFAULT_LARGE_BREAKPOINT;
+}
 
 /** @internal Unique ID that is used as a property name for renderer instances on DOM elements */
 export const RENDER_PROP_ID =
@@ -198,13 +266,28 @@ export class DOMRenderContext extends UIRenderContext {
     }
     this.root = root;
     this.addEventListeners();
+    this.viewportContext.update();
   }
 
   /** The root node that contains all rendered content (read-only) */
   readonly root: HTMLElement;
 
+  /** Observable viewport data */
+  @managedChild
+  readonly viewportContext = new DOMViewportContext();
+
+  /** Bound event handler function */
+  private readonly _updateViewportContext = () => this.viewportContext.update();
+
+  /** Timer ID for viewport context update (interval) */
+  private _updateViewportTimer?: any;
+
   /** Add all event handlers on the root element */
   addEventListeners() {
+    // add resize listener to keep track of viewport, use timer as a backup
+    window.addEventListener("resize", this._updateViewportContext);
+    this._updateViewportTimer = setInterval(this._updateViewportContext, 500);
+
     // add focus handler that blocks focus outside of modals
     this.root.removeEventListener("focusin", detractFocus, true);
     this.root.addEventListener("focusin", detractFocus, true);
@@ -232,6 +315,8 @@ export class DOMRenderContext extends UIRenderContext {
   /** Remove the rendered content from the screen when the renderer is destroyed */
   async onManagedStateDestroyingAsync() {
     await super.onManagedStateDestroyingAsync();
+    window.removeEventListener("resize", this._updateViewportContext);
+    clearInterval(this._updateViewportTimer);
     this.clear();
     if (this._isFixedRoot && this.root.parentNode) {
       document.body.removeChild(this.root);

--- a/src/DOMRenderContext.ts
+++ b/src/DOMRenderContext.ts
@@ -2,12 +2,12 @@ import {
   AppActivity,
   logUnhandledException,
   UIComponent,
+  UIComponentEvent,
   UIRenderable,
   UIRenderContext,
   UIRenderPlacement,
   UITheme,
 } from "typescene";
-import { UIComponentEvent } from "typescene/dist";
 import { BrowserApplication } from "./BrowserApplication";
 
 /** @internal Unique ID that is used as a property name for renderer instances on DOM elements */

--- a/src/DOMStyle.ts
+++ b/src/DOMStyle.ts
@@ -361,11 +361,11 @@ function addDecorationCSS(
   let textColor = decoration.textColor;
   if (textColor !== undefined) result.color = UITheme.replaceColor(textColor);
   let borderThickness = decoration.borderThickness;
-  if (borderThickness !== undefined) {
-    result.borderWidth = getCSSLength(borderThickness);
-    result.borderColor = UITheme.replaceColor(decoration.borderColor || "transparent");
-    result.borderStyle = decoration.borderStyle || "solid";
-  }
+  if (borderThickness !== undefined) result.borderWidth = getCSSLength(borderThickness);
+  let borderColor = decoration.borderColor;
+  if (borderColor != undefined) result.borderColor = UITheme.replaceColor(borderColor);
+  let borderStyle = decoration.borderStyle;
+  if (borderStyle != undefined) result.borderStyle = decoration.borderStyle;
 
   let borderRadius = decoration.borderRadius;
   if (borderRadius !== undefined)

--- a/src/DOMStyle.ts
+++ b/src/DOMStyle.ts
@@ -15,6 +15,9 @@ import { DOMRenderContext } from "./DOMRenderContext";
 /** @internal Number of logical pixels in a REM unit */
 export const DP_PER_REM = 16;
 
+/** Actual number of pixels in a REM unit */
+let _actualDPPerRem = 16;
+
 /** Flexbox justify options */
 const _flexJustifyOptions = {
   "start": "flex-start",
@@ -56,6 +59,24 @@ export function importStylesheet(url: string) {
 /** @internal Forget state of all styles that have already been defined, so that they will be redefined on next use */
 export function clearGlobalCSSState() {
   _cssDefined = {};
+}
+
+/** @internal Override REM size globally */
+export function setGlobalDpSize(size: number) {
+  _actualDPPerRem = size * DP_PER_REM;
+  setGlobalCSS({
+    html: { fontSize: _actualDPPerRem + "px" },
+  });
+}
+
+/** @internal Measure window width in DP units */
+export function getWindowInnerWidthDp() {
+  return (window.innerWidth / _actualDPPerRem) * DP_PER_REM;
+}
+
+/** @internal Measure window height in DP units */
+export function getWindowInnerHeightDp() {
+  return (window.innerHeight / _actualDPPerRem) * DP_PER_REM;
 }
 
 /** @internal Replace given CSS styles in the global root style sheet */

--- a/src/HMR.ts
+++ b/src/HMR.ts
@@ -1,38 +1,38 @@
 import { Component, ComponentConstructor } from "typescene";
 
-/** Encapsulates hot module reload (HMR) functions for a view module, which must export exactly one component constructor as `default` or `View` */
+/** @internal Handler that is used to update given class when its module is updated; used with e.g. `ViewActivity`, do not call on its own */
+export function autoUpdateHandler<T extends ComponentConstructor>(
+  module: any,
+  C: T,
+  methodName: string & keyof T
+) {
+  if (module.hot) {
+    module.hot.accept();
+    let old = module.hot.data?.autoUpdate;
+    setTimeout(() => {
+      if (old) {
+        if (C[methodName]) (C[methodName] as any)(old, C);
+      }
+    }, 0);
+    if (C[methodName]) {
+      module.hot.dispose((data: any) => {
+        (data || module.hot.data).autoUpdate = C;
+      });
+    }
+  }
+}
+
+/** @deprecated */
 export namespace HMR {
-  /** Enable hot module reloading for given view module (must be referenced by a `ViewActivity` class), to reload activity views that are created from given class without reinstantiating the activity itself */
+  /**
+   * Enable hot module reloading for given view module; does NOT work anymore.
+   * @deprecated in favor of `ViewActivity.autoUpdate()`
+   */
   export function enableViewReload<T extends ComponentConstructor>(
-    viewModule: any,
+    _viewModule: any,
     ViewClass: T
   ): T {
-    if (viewModule.hot) {
-      // accept new modules, and link up the new view class
-      viewModule.hot.accept();
-      if (viewModule.hot.data && viewModule.hot.data.updateActivity) {
-        setTimeout(() => {
-          ViewClass = ViewClass || viewModule.exports.default || viewModule.exports.View;
-          if (ViewClass && ViewClass.prototype instanceof Component) {
-            viewModule.hot.data.updateActivity(ViewClass);
-          }
-        }, 0);
-      }
-      setTimeout(() => {
-        // find the exported view class and add a dispose callback
-        // (to be called above after loading new module's view class)
-        ViewClass = ViewClass || viewModule.exports.default || viewModule.exports.View;
-        if (ViewClass && ViewClass.prototype instanceof Component) {
-          if ((ViewClass as any)["@updateActivity"]) {
-            viewModule.hot.dispose((data?: any) => {
-              // (Webpack supplies `data` but Parcel does not)
-              if (!data) data = viewModule.hot.data;
-              data.updateActivity = (ViewClass as any)["@updateActivity"];
-            });
-          }
-        }
-      }, 10);
-    }
+    // nothing here
     return ViewClass;
   }
 }


### PR DESCRIPTION
Gathering changes here for pushing to v3.1

- Added build targets for ES6, ES8 in separate folders, just like main module. Also added rollup output for each target so they can be used as `.min.js` files
- Fix some styling issues
- Implemented viewport context, to enable bindings such as `bind("viewportContext.narrow")` which update to 'true' when the viewport becomes a certain size. For now this includes narrow / wide / short / tall but these can be extended later.