### PR TITLE
Fix: allow swapping raw output elements

### DIFF
--- a/src/renderers/DOMContainerUpdater.ts
+++ b/src/renderers/DOMContainerUpdater.ts
@@ -243,10 +243,25 @@ export class DOMContainerUpdater {
       } else {
         DOMRenderContext.scheduleRender(() => {
           if (this._stopped || !component.managedState) return output;
-          if (lastOutput && lastOutput.element.parentNode === this.element) {
-            // use placeholder for components that have no output
+          if (
+            lastOutput &&
+            lastOutput !== output &&
+            lastOutput.element.parentNode === this.element
+          ) {
             if (!output || !output.element) {
+              // use placeholder for components that have no output
               output = this._getPlaceholder(component);
+            } else {
+              // if new output is already a child element somewhere,
+              // don't just remove it but replace with a placeholder
+              if (output.element.parentNode) {
+                let swap = this._getPlaceholder(component);
+                let elt = output.element;
+                elt.parentNode!.replaceChild(swap.element, elt);
+                output.element = swap.element;
+                swap.element = elt;
+                output = swap;
+              }
             }
 
             // update existing element

--- a/src/renderers/RendererBase.ts
+++ b/src/renderers/RendererBase.ts
@@ -210,8 +210,10 @@ export abstract class RendererBase<
         element.dataset.transitionT = "revealing";
       }
     }
-    let output = new UIRenderContext.Output(component, element);
-    component.lastRenderOutput = output as any;
+    let output =
+      component.lastRenderOutput && component.lastRenderOutput.element === element
+        ? component.lastRenderOutput
+        : (component.lastRenderOutput = new UIRenderContext.Output(component, element));
     this._lastRenderCallback = e.renderCallback(output, this.afterRender.bind(this));
   }
 


### PR DESCRIPTION
There was an issue where output elements got deleted if they were existing child elements that got swapped with other child elements. This patch replaces existing child elements first with a placeholder, and updates the original render output object. This means elements can now be safely swapped without losing one of the elements.