### PR TITLE
Use named styles for AlertDialog and DropdownMenu components

### DIFF
--- a/src/BrowserTheme.ts
+++ b/src/BrowserTheme.ts
@@ -1,6 +1,6 @@
-import { UITheme } from "typescene";
-import { AlertDialogBuilder } from "./components/AlertDialog";
-import { DropdownMenuBuilder } from "./components/DropdownMenu";
+import { UITheme, UIStyle } from "typescene";
+import { AlertDialogBuilder, alertDialogStyles } from "./components/AlertDialog";
+import { DropdownMenuBuilder, dropdownMenuStyles } from "./components/DropdownMenu";
 import { getCSSLength, setGlobalCSS } from "./DOMStyle";
 
 const BASE_FONT_FAMILY =
@@ -12,198 +12,229 @@ export class BrowserTheme extends UITheme {
   constructor() {
     super();
 
-    this.setStyle("container", {
-      decoration: {
-        css: {
-          display: "flex",
-          textAlign: "start||left",
+    // override color set:
+    this.colors = {
+      ...this.colors,
+      black: "#000000",
+      darkerGray: "#333333",
+      darkGray: "#777777",
+      lightGray: "#dddddd",
+      white: "#ffffff",
+      slate: "#667788",
+      lightSlate: "#c0c8d0",
+      red: "#ee3333",
+      orange: "#ee9922",
+      yellow: "#ddcc33",
+      lime: "#99bb33",
+      green: "#44aa44",
+      turquoise: "#33aaaa",
+      cyan: "#33bbbb",
+      blue: "#3355aa",
+      violet: "#5533aa",
+      purple: "#8833aa",
+      magenta: "#dd4488",
+      primary: "@blue",
+      accent: "@purple",
+      appBackground: "@background",
+    };
+
+    // set or extend global theme styles
+    this.styles = UIStyle.group(this.styles, alertDialogStyles, dropdownMenuStyles, {
+      // use CSS style for containers to use flexbox:
+      "container": {
+        decoration: {
+          css: {
+            display: "flex",
+            textAlign: "start||left",
+          },
         },
       },
-    });
-    this.setStyle("control", {
-      textStyle: {
-        fontFamily: BASE_FONT_FAMILY,
-        fontSize: BASE_FONT_SIZE,
-        fontWeight: "normal",
-        lineHeight: "normal",
-        italic: false,
-        lineBreakMode: "pre",
-      },
-    });
 
-    this.setStyle("spacer", {
-      dimensions: { grow: 1, width: 8, height: 8 },
-      position: { gravity: "stretch" },
-    });
-    this.setStyle("separator", {
-      dimensions: { grow: 0, shrink: 0 },
-      position: { gravity: "stretch" },
-    });
-
-    // label styles
-    this.setStyle("label", {
-      dimensions: { maxWidth: "100%" },
-      decoration: { css: { margin: "calc(1rem - .5em) 0" } },
-      textStyle: { lineBreakMode: "ellipsis" },
-    });
-    this.setStyle("label_close", {
-      decoration: { css: { margin: "0" } },
-    });
-    this.setStyle("heading1", {
-      textStyle: { fontSize: 60, fontWeight: 200, letterSpacing: -0.5 },
-    });
-    this.setStyle("heading2", {
-      textStyle: { fontSize: 24 },
-    });
-    this.setStyle("heading3", {
-      textStyle: { fontSize: 18, bold: true },
-    });
-    this.setStyle("paragraph", {
-      textStyle: { lineBreakMode: "pre-wrap", lineHeight: 1.4 },
-      decoration: { css: { cursor: "text" } },
-    });
-
-    // button styles
-    this.setStyle("button", {
-      dimensions: { minWidth: 96 },
-      textStyle: {
-        align: "center",
-        lineBreakMode: "ellipsis",
-      },
-      decoration: {
-        borderThickness: 0,
-        background: "@controlBase",
-        textColor: "@primary",
-        borderRadius: 4,
-        padding: { y: 8, x: 12 },
-        css: {
-          cursor: "pointer",
-          transition: "all .2s ease",
+      // control styles:
+      "control": {
+        textStyle: {
+          fontFamily: BASE_FONT_FAMILY,
+          fontSize: BASE_FONT_SIZE,
+          fontWeight: "normal",
+          lineHeight: "normal",
+          italic: false,
+          lineBreakMode: "pre",
         },
       },
-    })
-      .addState("pressed", {
-        decoration: { background: "@primary", textColor: "@primary:text" },
-      })
-      .addState("hover", {
-        decoration: { background: "@primary", textColor: "@primary:text" },
-      })
-      .addState("disabled", {
+      "spacer": {
+        dimensions: { grow: 1, width: 8, height: 8 },
+        position: { gravity: "stretch" },
+      },
+      "separator": {
+        dimensions: { grow: 0, shrink: 0 },
+        position: { gravity: "stretch" },
+      },
+
+      // label styles:
+      "label": {
+        dimensions: { maxWidth: "100%" },
+        decoration: { css: { margin: "calc(1rem - .5em) 0" } },
+        textStyle: { lineBreakMode: "ellipsis" },
+      },
+      "label_close": {
+        decoration: { css: { margin: "0" } },
+      },
+      "heading1": {
+        textStyle: { fontSize: 60, fontWeight: 200, letterSpacing: -0.5 },
+      },
+      "heading2": {
+        textStyle: { fontSize: 24 },
+      },
+      "heading3": {
+        textStyle: { fontSize: 18, bold: true },
+      },
+      "paragraph": {
+        textStyle: { lineBreakMode: "pre-wrap", lineHeight: 1.4 },
+        decoration: { css: { cursor: "text" } },
+      },
+
+      // button styles:
+      "button": UIStyle.create({
+        dimensions: { minWidth: 96 },
+        textStyle: {
+          align: "center",
+          lineBreakMode: "ellipsis",
+        },
         decoration: {
           borderThickness: 0,
           background: "@controlBase",
           textColor: "@primary",
-          css: { opacity: ".5", cursor: "inherit" },
+          borderRadius: 4,
+          padding: { y: 8, x: 12 },
+          css: {
+            cursor: "pointer",
+            transition: "all .2s ease",
+          },
         },
-      });
-    this.setStyle("button_primary", {
-      decoration: {
-        background: "@primary",
-        textColor: "@primary:text",
-        borderThickness: 1,
-        borderColor: "@primary",
-      },
-    }).addState("hover", {
-      decoration: {
-        background: "@primary^+30%",
-        borderThickness: 1,
-        borderColor: "@primary^+30%",
-      },
-    });
-    this.setStyle("button_borderless", {
-      dimensions: { minWidth: 16, minHeight: 16 },
-      decoration: {
-        background: "transparent",
-        borderThickness: 1,
-        borderColor: "transparent",
-        padding: { y: 6, x: 12 },
-      },
-    }).addState("hover", {
-      decoration: { background: "@controlBase^-50%/30%", textColor: "@primary" },
-    });
-    this.setStyle("button_outline", {
-      decoration: {
-        borderThickness: 1,
-        borderColor: "@primary",
-      },
-    });
-    this.setStyle("button_link", {
-      dimensions: { minWidth: 16, minHeight: 16 },
-      textStyle: { align: "start||left" },
-      decoration: { background: "transparent" },
-    })
-      .addState("hover", {
-        textStyle: { underline: true },
-        decoration: { background: "transparent", textColor: "@primary" },
       })
-      .addState("disabled", {
-        decoration: { background: "transparent", textColor: "@primary" },
-      });
-    this.setStyle("button_large", {
-      dimensions: { minWidth: 128 },
-      textStyle: { fontWeight: 200, fontSize: 16 },
-      decoration: {
-        background: "@primary",
-        textColor: "@primary:text",
-        borderRadius: 32,
-        padding: { y: 12, x: 16 },
-      },
-    });
-    this.setStyle("button_small", {
-      dimensions: { minWidth: 64 },
-      textStyle: { fontSize: 12 },
-      decoration: {
-        borderThickness: 1,
-        borderColor: "@controlBase^-20%",
-        padding: { y: 4, x: 8 },
-      },
-    });
-    this.setStyle("button_icon", {
-      dimensions: { minWidth: 32, minHeight: 32 },
-      position: { gravity: "center" },
-      decoration: {
-        background: "transparent",
-        borderRadius: "50%",
-        padding: 0,
-      },
-    }).addState("hover", {
-      decoration: { background: "@decoration^-50%/30%", textColor: "@primary" },
-    });
+        .addState("pressed", {
+          decoration: { background: "@primary", textColor: "@primary:text" },
+        })
+        .addState("hover", {
+          decoration: { background: "@primary", textColor: "@primary:text" },
+        })
+        .addState("disabled", {
+          decoration: {
+            borderThickness: 0,
+            background: "@controlBase",
+            textColor: "@primary",
+            css: { opacity: ".5", cursor: "inherit" },
+          },
+        }),
+      "button_primary": UIStyle.create({
+        decoration: {
+          background: "@primary",
+          textColor: "@primary:text",
+          borderThickness: 1,
+          borderColor: "@primary",
+        },
+      }).addState("hover", {
+        decoration: {
+          background: "@primary^+30%",
+          borderThickness: 1,
+          borderColor: "@primary^+30%",
+        },
+      }),
+      "button_borderless": UIStyle.create({
+        dimensions: { minWidth: 16, minHeight: 16 },
+        decoration: {
+          background: "transparent",
+          borderThickness: 1,
+          borderColor: "transparent",
+          padding: { y: 6, x: 12 },
+        },
+      }).addState("hover", {
+        decoration: { background: "@controlBase^-50%/30%", textColor: "@primary" },
+      }),
+      "button_outline": UIStyle.create({
+        decoration: {
+          borderThickness: 1,
+          borderColor: "@primary",
+        },
+      }),
+      "button_link": UIStyle.create({
+        dimensions: { minWidth: 16, minHeight: 16 },
+        textStyle: { align: "start||left" },
+        decoration: { background: "transparent" },
+      })
+        .addState("hover", {
+          textStyle: { underline: true },
+          decoration: { background: "transparent", textColor: "@primary" },
+        })
+        .addState("disabled", {
+          decoration: { background: "transparent", textColor: "@primary" },
+        }),
+      "button_large": UIStyle.create({
+        dimensions: { minWidth: 128 },
+        textStyle: { fontWeight: 200, fontSize: 16 },
+        decoration: {
+          background: "@primary",
+          textColor: "@primary:text",
+          borderRadius: 32,
+          padding: { y: 12, x: 16 },
+        },
+      }),
+      "button_small": UIStyle.create({
+        dimensions: { minWidth: 64 },
+        textStyle: { fontSize: 12 },
+        decoration: {
+          borderThickness: 1,
+          borderColor: "@controlBase^-20%",
+          padding: { y: 4, x: 8 },
+        },
+      }),
+      "button_icon": UIStyle.create({
+        dimensions: { minWidth: 32, minHeight: 32 },
+        position: { gravity: "center" },
+        decoration: {
+          background: "transparent",
+          borderRadius: "50%",
+          padding: 0,
+        },
+      }).addState("hover", {
+        decoration: { background: "@decoration^-50%/30%", textColor: "@primary" },
+      }),
 
-    // text field styles
-    this.setStyle("textfield", {
-      decoration: {
-        background: "@white",
-        textColor: "@white:text",
-        borderColor: "@controlBase^-20%",
-        borderThickness: 1,
-        borderRadius: 4,
-        padding: 8,
-        css: { cursor: "text" },
-      },
-      textStyle: {
-        lineBreakMode: "pre-wrap",
-      },
-    });
-    this.setStyle("textfield_borderless", {
-      decoration: {
-        background: "transparent",
-        borderThickness: 0,
-        borderRadius: 0,
-        padding: 0,
-      },
-    }).addState("focused", {
-      decoration: { css: { boxShadow: "none" } },
-    });
+      // text field styles:
+      "textfield": UIStyle.create({
+        decoration: {
+          background: "@white",
+          textColor: "@white:text",
+          borderColor: "@controlBase^-20%",
+          borderThickness: 1,
+          borderRadius: 4,
+          padding: 8,
+          css: { cursor: "text" },
+        },
+        textStyle: {
+          lineBreakMode: "pre-wrap",
+        },
+      }),
+      "textfield_borderless": UIStyle.create({
+        decoration: {
+          background: "transparent",
+          borderThickness: 0,
+          borderRadius: 0,
+          padding: 0,
+        },
+      }).addState("focused", {
+        decoration: { css: { boxShadow: "none" } },
+      }),
 
-    // toggle styles
-    this.setStyle("toggle", {
-      decoration: { textColor: "@text", cssClassNames: ["UI__CustomToggle"] },
-    });
+      // toggle style:
+      "toggle": {
+        decoration: { textColor: "@text", cssClassNames: ["UI__CustomToggle"] },
+      },
 
-    // image styles
-    this.setStyle("image", {
-      position: { gravity: "center" },
+      // image style:
+      "image": {
+        position: { gravity: "center" },
+      },
     });
   }
 
@@ -212,36 +243,6 @@ export class BrowserTheme extends UITheme {
 
   /** Dropdown menu component builder */
   MenuBuilder = DropdownMenuBuilder;
-
-  /** Expanded set of default colors */
-  colors: UITheme["colors"] = {
-    black: "#000000",
-    darkerGray: "#333333",
-    darkGray: "#777777",
-    lightGray: "#dddddd",
-    white: "#ffffff",
-    slate: "#667788",
-    lightSlate: "#c0c8d0",
-    red: "#ee3333",
-    orange: "#ee9922",
-    yellow: "#ddcc33",
-    lime: "#99bb33",
-    green: "#44aa44",
-    turquoise: "#33aaaa",
-    cyan: "#33bbbb",
-    blue: "#3355aa",
-    violet: "#5533aa",
-    purple: "#8833aa",
-    magenta: "#dd4488",
-    primary: "@blue",
-    accent: "@purple",
-    background: "@white",
-    appBackground: "@background",
-    text: "@background:text",
-    controlBase: "@background",
-    separator: "@background^-50%/20%",
-    modalShade: "@black",
-  };
 
   /** Default icons in SVG format (base implementation adapted from Material Design icons by Google) */
   icons: UITheme["icons"] = {

--- a/src/DOMStyle.ts
+++ b/src/DOMStyle.ts
@@ -136,9 +136,10 @@ export function applyElementCSS(
     if (UIStyle.isStyleOverride(component.textStyle, styleInstance)) {
       addTextStyleCSS(inline, component.textStyle);
     }
+    let grow = +component.dimensions.grow!;
     if (
-      (component.shrinkwrap && component.dimensions.grow) ||
-      (!component.shrinkwrap && !component.dimensions.grow)
+      (component.shrinkwrap === true && grow) ||
+      (component.shrinkwrap === false && !grow)
     ) {
       inline.flexGrow = component.shrinkwrap ? "0" : "1";
     }

--- a/src/components/AlertDialog.ts
+++ b/src/components/AlertDialog.ts
@@ -3,6 +3,7 @@ import {
   ComponentConstructor,
   ConfirmationDialogBuilder,
   strf,
+  UIStyle,
   UIBorderlessButton,
   UICell,
   UICloseRow,
@@ -10,14 +11,44 @@ import {
   UIFlowCell,
   UILabel,
   UILinkButton,
-  UIOppositeRow,
   UIParagraph,
   UIPrimaryButton,
   UISpacer,
   ViewComponent,
   Stringable,
   UICloseColumn,
+  UIRow,
 } from "typescene";
+
+export const alertDialogStyles = UIStyle.group({
+  "alertDialog": {
+    decoration: {
+      background: "@background",
+      borderRadius: 4,
+      dropShadow: 0.65,
+    },
+    position: { gravity: "center" },
+    dimensions: { maxWidth: 400, width: "95vw" },
+  },
+  "alertDialog-titlebar": {
+    decoration: {
+      background: "@primary",
+      textColor: "@primary.text",
+    },
+    dimensions: { height: 40 },
+  },
+  "alertDialog-title": {},
+  "alertDialog-buttonRow": {
+    containerLayout: { distribution: "end" },
+    decoration: { padding: 0 },
+  },
+  "alertDialog-cancelButton": {
+    dimensions: { grow: 0 },
+  },
+  "alertDialog-confirmButton": {
+    dimensions: { grow: 0 },
+  },
+});
 
 /** Default modal message dialog UI component; emits `Confirm` and `CloseModal` events */
 export class AlertDialog extends ViewComponent.with({
@@ -33,29 +64,25 @@ export class AlertDialog extends ViewComponent.with({
   }),
   view: UICell.with(
     {
-      background: "@background",
-      borderRadius: 4,
-      position: { gravity: "center" },
-      dimensions: { maxWidth: 400, width: "95vw" },
-      dropShadow: 0.65,
+      style: "alertDialog",
       revealTransition: "up-fast",
     },
     UIFlowCell.with(
       {
-        background: "@primary",
-        dimensions: { height: 40 },
+        style: "alertDialog-titlebar",
         hidden: bind("title|!"),
         onMouseDown: "+DragContainer",
       },
       UICloseRow.with(
         UISpacer.withWidth(16),
-        UIExpandedLabel.withText(bind("title"), { color: "@primary:text" }),
+        UIExpandedLabel.withText(bind("title"), "alertDialog-title"),
         UIBorderlessButton.with({
           position: { gravity: "center" },
           icon: "close",
           onClick: "+CloseModal",
           iconSize: 18,
-          iconColor: "@primary:text",
+          iconColor: "currentColor",
+          textStyle: { color: "inherit" },
           disableKeyboardFocus: true,
         })
       )
@@ -66,14 +93,20 @@ export class AlertDialog extends ViewComponent.with({
         content: bind("messageLabels", []),
       }),
       UISpacer.withHeight(24),
-      UIOppositeRow.with(
-        { padding: 0 },
+      UIRow.with(
+        {
+          style: "alertDialog-buttonRow",
+        },
         UILinkButton.with({
+          style: "alertDialog-cancelButton",
+          shrinkwrap: "auto",
           hidden: bind("cancelButtonLabel|!"),
           label: bind("cancelButtonLabel"),
           onClick: "+CloseModal",
         }),
         UIPrimaryButton.with({
+          style: "alertDialog-confirmButton",
+          shrinkwrap: "auto",
           label: bind("confirmButtonLabel"),
           onClick: "+Confirm",
           requestFocus: true,

--- a/src/components/DropdownMenu.ts
+++ b/src/components/DropdownMenu.ts
@@ -13,12 +13,43 @@ import {
   Stringable,
 } from "typescene";
 
+export const dropdownMenuStyles = UIStyle.group({
+  "dropdownMenu": {
+    dimensions: { minWidth: 50, maxWidth: 280 },
+    decoration: {
+      background: "@background",
+      borderRadius: 4,
+      dropShadow: 0.8,
+    },
+  },
+  "dropdownMenu-item": UIStyle.create({
+    containerLayout: { axis: "horizontal" },
+    decoration: {
+      padding: { x: 16 },
+      css: { cursor: "pointer" },
+    },
+  })
+    .addState("hover", {
+      decoration: {
+        background: "@primary",
+        textColor: "@primary.text",
+      },
+    })
+    .addState("focused", {
+      decoration: {
+        background: "@primary",
+        textColor: "@primary.text",
+      },
+    }),
+  "dropdownMenu-label": {},
+  "dropdownMenu-hint": {
+    textStyle: { color: "@text/50%", fontSize: 12 },
+  },
+});
+
 /** Encapsulates a menu; items are mixed in by `DropdownMenuBuilder` */
 class DropdownMenu extends UICell.with({
-  background: "@background",
-  dimensions: { minWidth: 50, maxWidth: 280 },
-  borderRadius: 4,
-  dropShadow: 0.8,
+  style: "dropdownMenu",
   onArrowDownKeyPress(e: UIComponentEvent) {
     if (!(e.source instanceof DropdownMenu)) return;
     for (let item of (this as UICell).content) {
@@ -37,9 +68,6 @@ class DropdownMenu extends UICell.with({
 
 /** Default dropdown menu builder, used by `UIMenu` */
 export class DropdownMenuBuilder extends UIMenuBuilder {
-  static labelStyleMixin: Partial<UIStyle.TextStyle> = {};
-  static hintStyleMixin: Partial<UIStyle.TextStyle> = { color: "@text/50%", fontSize: 12 };
-
   clear() {
     this._items.length = 0;
     return this;
@@ -51,8 +79,8 @@ export class DropdownMenuBuilder extends UIMenuBuilder {
     icon?: string,
     hint?: Stringable,
     hintIcon?: string,
-    textStyle: Partial<UIStyle.TextStyle> = DropdownMenuBuilder.labelStyleMixin,
-    hintStyle: Partial<UIStyle.TextStyle> = DropdownMenuBuilder.hintStyleMixin
+    textStyle?: Partial<UIStyle.TextStyle>,
+    hintStyle?: Partial<UIStyle.TextStyle>
   ) {
     function onClick(this: UIComponent) {
       let menu = this.getParentComponent(DropdownMenu);
@@ -62,17 +90,8 @@ export class DropdownMenuBuilder extends UIMenuBuilder {
     this._items.push(
       UICell.with(
         {
-          layout: { axis: "horizontal" },
-          css: { cursor: "pointer" },
+          style: "dropdownMenu-item",
           allowKeyboardFocus: true,
-          onMouseEnter() {
-            this.background = "@primary";
-            this.textColor = "@primary:text";
-          },
-          onMouseLeave() {
-            this.background = "";
-            this.textColor = "";
-          },
           onClick,
           onEnterKeyPress: onClick,
           onArrowDownKeyPress: function () {
@@ -82,13 +101,22 @@ export class DropdownMenuBuilder extends UIMenuBuilder {
             this.requestFocusPrevious();
           },
         },
-        UISpacer.with({ dimensions: { width: 16, shrink: 0 }, shrinkwrap: true }),
-        UIExpandedLabel.with({ text, icon, iconMargin: 8, textStyle }),
+        UIExpandedLabel.with({
+          text,
+          icon,
+          iconMargin: 8,
+          style: "dropdownMenu-label",
+          textStyle,
+        }),
         hint ? UISpacer.withWidth(8) : undefined,
         hint
-          ? UILabel.with({ text: hint, icon: hintIcon, textStyle: hintStyle })
-          : undefined,
-        UISpacer.withWidth(16)
+          ? UILabel.with({
+              text: hint,
+              icon: hintIcon,
+              style: "dropdownMenu-hint",
+              textStyle: hintStyle,
+            })
+          : undefined
       )
     );
     return this;


### PR DESCRIPTION
Changed AlertDialog and DropdownMenu *builders* to use proper named styles, rather than hardcoded style overrides.

This makes it possible to change styles for both, without having to re-implement builders from scratch.