### PR TITLE
Set button type attribute to button

### DIFF
--- a/src/renderers/UIButton.ts
+++ b/src/renderers/UIButton.ts
@@ -15,9 +15,9 @@ class UIButtonRenderer extends RendererBase<
 
   /** Create output element, used by base class */
   protected createElement() {
-    let element = document.createElement(
-      this.component.accessibleRole === "link" ? "a" : "button"
-    );
+    let isLink = this.component.accessibleRole === "link";
+    let element = document.createElement(isLink ? "a" : "button");
+    if (!isLink) element.type = "button";
     element.tabIndex = this.component.isKeyboardFocusable() ? 0 : -1;
     applyElementCSS(this.component, element, true);
     setTextOrHtmlContent(element, {


### PR DESCRIPTION
This avoids issues with onSubmit being called twice if the event handler for the button is set to Submit.