### PR TITLE
Option to remove root element when destroying app

### DIFF
--- a/src/BrowserApplication.ts
+++ b/src/BrowserApplication.ts
@@ -64,13 +64,13 @@ export class BrowserApplication extends Application {
   }
 
   /**
-   * Use given DOM element to contain the application output, by creating a new renderer instance that is mounted to given element.
+   * Use given DOM element to contain the application output, by creating a new renderer instance that is mounted to given element. Optionally, the element will be removed when the application and/or renderer is destroyed.
    * @note By default, `BrowserApplication` occupies the entire page and clears everything else from the same page. Use this method _immediately_ after creating the application to prevent clearing the page, or supply a DOM element as a constructor argument if instantiating the application manually.
    */
-  mount(element: HTMLElement) {
+  mount(element: HTMLElement, removeOnDestroy?: boolean) {
     this._root = element;
     if (this.renderContext) {
-      this.renderContext = new DOMRenderContext(element);
+      this.renderContext = new DOMRenderContext(element, removeOnDestroy);
     }
     return this;
   }

--- a/src/DOMRenderContext.ts
+++ b/src/DOMRenderContext.ts
@@ -256,15 +256,17 @@ export class DOMRenderContext extends UIRenderContext {
   }
 
   /** Create a new application render context that places elements within given root element */
-  constructor(root?: HTMLElement) {
+  constructor(root?: HTMLElement, removeOnDestroy?: boolean) {
     super();
 
     // set or create root element
-    if (!root) {
+    if (root) {
+      this.root = root;
+      this._removeOnDestroy = !!removeOnDestroy;
+    } else {
       root = DOMRenderContext.createFixedRootElement();
-      this._isFixedRoot = true;
+      this._removeOnDestroy = true;
     }
-    this.root = root;
     this.addEventListeners();
     this.viewportContext.update();
   }
@@ -318,8 +320,8 @@ export class DOMRenderContext extends UIRenderContext {
     window.removeEventListener("resize", this._updateViewportContext);
     clearInterval(this._updateViewportTimer);
     this.clear();
-    if (this._isFixedRoot && this.root.parentNode) {
-      document.body.removeChild(this.root);
+    if (this._removeOnDestroy && this.root.parentNode) {
+      this.root.parentNode.removeChild(this.root);
     }
   }
 
@@ -695,7 +697,7 @@ export class DOMRenderContext extends UIRenderContext {
   }
 
   private _page?: DOMRenderOutput;
-  private _isFixedRoot?: boolean;
+  private _removeOnDestroy?: boolean;
 }
 
 /** Helper function to fix positioning of a dropdown menu or vertical popover */


### PR DESCRIPTION
Added a second parameter to the `BrowserApplication.mount()` method which is passed on to the renderer.